### PR TITLE
Parsing a float is now deprecated

### DIFF
--- a/lib/LongitudeOne/Geo/String/Parser.php
+++ b/lib/LongitudeOne/Geo/String/Parser.php
@@ -52,6 +52,10 @@ class Parser
     {
         $this->lexer = new Lexer();
 
+        if (is_float($input)) {
+            trigger_error('Since longitudeone/geo-parser 2.1: Passing a float to LongitudeOne\Geo\String\Parser::__construct() is deprecated. Use a string instead.', E_USER_DEPRECATED);
+        }
+
         if (null !== $input) {
             $this->input = (string) $input;
         }
@@ -64,6 +68,10 @@ class Parser
      */
     public function parse($input = null): float|int|array
     {
+        if (is_float($input)) {
+            trigger_error('Since longitudeone/geo-parser 2.1: Passing a float to LongitudeOne\Geo\String\Parser::parse() is deprecated. Use a string instead.', E_USER_DEPRECATED);
+        }
+
         if (null !== $input) {
             $this->input = (string) $input;
         }

--- a/quality/php-mess-detector/ruleset.xml
+++ b/quality/php-mess-detector/ruleset.xml
@@ -23,8 +23,8 @@
     </rule>
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
         <properties>
-            <!-- Set the maximum complexity to 68, because of historical code -->
-            <property name="maximum" value="68" />
+            <!-- Set the maximum complexity to 69, because of historical code -->
+            <property name="maximum" value="69" />
         </properties>
     </rule>
     <!-- Import the entire naming rule set -->

--- a/tests/LongitudeOne/Geo/String/Tests/ParserTest.php
+++ b/tests/LongitudeOne/Geo/String/Tests/ParserTest.php
@@ -75,7 +75,6 @@ class ParserTest extends TestCase
         yield ['40°N', 40];
         yield ['40°S', -40];
         yield ['45.24', 45.24];
-        yield [45.24, 45.24];
         yield ['45.24°', 45.24];
         yield ['+45.24°', 45.24];
         yield ['45.24° S', -45.24];
@@ -127,11 +126,11 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @param int|float|int[]|float[] $expected
+     * @param int|float|float[]|int[] $expected
      *
      * @dataProvider dataSourceGood
      */
-    public function testGoodValues(string|int|float $input, $expected): void
+    public function testGoodValues(string|int|float $input, int|float|array $expected): void
     {
         $parser = new Parser($input);
 


### PR DESCRIPTION
Because of improvements on doctrine/lexer:v3, parsing a float is now deprecated.